### PR TITLE
Feature/dev setup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.formatting.provider": "black"
+}

--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
-
-
 python -m venv venv
-source venv/Scripts/activate
+
+if [ "$OSTYPE" == "msys" ]; then
+    source venv/Scripts/activate
+else
+    source venv/bin/activate
+fi
+
 pip install -r requirements.txt


### PR DESCRIPTION
Small QoL improvements:
- Sets `black` as the default formatter
- Improves the `dev-setup` script so it runs the proper command depending on the OS